### PR TITLE
Fix broken directory reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Visual Studio Code theme that syncs with your wallpaper palette in real time usi
     This extension relies on wallust for generating color palettes. Ensure wallust is installed and properly configured.
 
 2. **Templates:**
-    Two wallust templates are required, available in the [assets/templates](./assets/templates) directory of this repository. These templates must be referenced in your wallust configuration.
+    Two wallust templates are required, available in the [templates](./templates) directory of this repository. These templates must be referenced in your wallust configuration.
 
 3. **Configure `wallust.toml`:**
     Add the following entries to your `wallust.toml` file to generate the necessary color files:


### PR DESCRIPTION
This pull request updates the `README.md` file to fix a directory reference for wallust templates.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Corrected the directory path for wallust templates from `[assets/templates]` to `[templates]` to ensure accurate instructions for users.