### PR TITLE
feat(theme): add activity bar color support when set position to top/bottom

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -360,6 +360,26 @@ export default (colors: Color[], bordered: boolean) => {
             'activityBarBadge.background': semantic.accent.hex(),
             'activityBarBadge.foreground': contrastFg.hex(),
 
+            // Activity Bar (Top position)
+            'activityBarTop.foreground': semantic.fg.hex(),
+            'activityBarTop.inactiveForeground': semantic.fgMuted.hex(),
+            'activityBarTop.activeForeground': semantic.fg.hex(),
+            'activityBarTop.background': (bordered ? semantic.bg : semantic.bgElevated).hex(),
+            'activityBarTop.border': bordered ? semantic.fgMuted.hex() + alpha.faint : semantic.bg.hex(),
+            'activityBarTop.activeBorder': semantic.accent.hex(),
+            'activityBarTopBadge.background': semantic.accent.hex(),
+            'activityBarTopBadge.foreground': contrastFg.hex(),
+
+            // Activity Bar (Bottom position)
+            'activityBarBottom.foreground': semantic.fg.hex(),
+            'activityBarBottom.inactiveForeground': semantic.fgMuted.hex(),
+            'activityBarBottom.activeForeground': semantic.fg.hex(),
+            'activityBarBottom.background': (bordered ? semantic.bgElevated : semantic.bg).hex(),
+            'activityBarBottom.border': bordered ? semantic.fgMuted.hex() + alpha.faint : semantic.bg.hex(),
+            'activityBarBottom.activeBorder': semantic.accent.hex(),
+            'activityBarBottomBadge.background': semantic.accent.hex(),
+            'activityBarBottomBadge.foreground': contrastFg.hex(),
+
             // ================================================================
             // Sidebar
             // ================================================================


### PR DESCRIPTION
When Activity Bar position is set to top/bottom, it is not using the Wallust colors.
- Added color tokens for top-positioned activity bar.
- Added color tokens for bottom-positioned activity bar.
- Also this fixes the button colors appearing same as background when generating white colors scheme.

**Before:**
<img width="328" height="181" alt="darkbefore" src="https://github.com/user-attachments/assets/cc0f5b3a-37b4-4907-ab0b-50df47e27dec" /> <img width="325" height="202" alt="lightbefore" src="https://github.com/user-attachments/assets/bd61c0ac-e0b5-4245-b908-6d8a6710ad58" />

**After:**
Top Position:
<img width="357" height="203" alt="darkafter" src="https://github.com/user-attachments/assets/34b2b6d1-13bf-4217-964e-4f18d47055c4" /> <img width="324" height="224" alt="lightafter" src="https://github.com/user-attachments/assets/143c56e8-1ddc-4680-8424-90356f77eab3" />

Bottom Position:
<img width="357" height="203" alt="darkafter" src="https://github.com/user-attachments/assets/212e1967-69c5-49ba-b91c-1cf183d75ca8" /> <img width="324" height="224" alt="lightafter" src="https://github.com/user-attachments/assets/a82df078-a2f3-42ef-9c2b-07266fc54efe" />
